### PR TITLE
DO-100 Allow nesting bundler exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Synchronised Migration
 
+## Unreleased
+
+* [DO-100] Allow nesting bundler exec
+
 ## 0.1.0
 
 * [DO-70] Use Redis to synchronise migrations across multiple deployments

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ You may override these settings through environment variables.
 
 ```
 SYNCHRONISED_COMMAND=bin/launch/migrate
+WITH_CLEAN_BUNDLER_ENV=1 # Non-empty for true
 REDLOCK_TIMEOUT_MS=3600000
 REDLOCK_RETRY_DELAY_MS=200
 REDLOCK_LOCK_KEY=migration-in-progress

--- a/lib/synchronised_migration/main.rb
+++ b/lib/synchronised_migration/main.rb
@@ -49,7 +49,14 @@ class SynchronisedMigration::Main
   end
 
   def migrate
-    Kernel.system target_command
+    return Kernel.system target_command unless with_clean_env?
+    Bundler.with_clean_env do
+      Kernel.system target_command
+    end
+  end
+
+  def with_clean_env?
+    not ENV.fetch('WITH_CLEAN_BUNDLER_ENV', '').empty?
   end
 
   def migration_failed?

--- a/spec/synchronised_migration/main_spec.rb
+++ b/spec/synchronised_migration/main_spec.rb
@@ -27,6 +27,8 @@ describe SynchronisedMigration::Main do
         method.call *args
       }
 
+      allow(Bundler).to receive(:with_clean_env).and_call_original
+
       stub_const(
         'RedisConfig', double(
           get: {
@@ -45,7 +47,21 @@ describe SynchronisedMigration::Main do
         expect(redis).to have_received(:get).with('migration-failed')
         expect(redis).to have_received(:set).with('migration-failed', 1)
         expect(Kernel).to have_received(:system)
+        expect(Bundler).not_to have_received(:with_clean_env)
         expect(redis).to have_received(:del).with('migration-failed')
+      end
+    end
+
+    context 'when require a clean Bundler environment' do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with('WITH_CLEAN_BUNDLER_ENV', '').and_return('1')
+      end
+
+      it 'executes it with a clean Bundler environment' do
+        expect(result).to be_success
+        expect(Kernel).to have_received(:system)
+        expect(Bundler).to have_received(:with_clean_env)
       end
     end
 


### PR DESCRIPTION
# Why?

The Raketask could be executed within `bundle exec`, but then it will force the migrate command to be in the same bundler environment.

This PR creates an option for "undoing" `bundle exec` by the method provided by Bundler so that the migrate command can itself be in a separate bundler environment with a different Gemfile.