### PR TITLE
DO-105 Use the original environment instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Synchronised Migration
 
+## Unreleased
+
+* [DO-105] Use the `original` environment instead
+
 ## 1.0.1
 
 * [DO-100] Address the Travis issue

--- a/lib/synchronised_migration/main.rb
+++ b/lib/synchronised_migration/main.rb
@@ -50,7 +50,7 @@ class SynchronisedMigration::Main
 
   def migrate
     return Kernel.system target_command unless with_clean_env?
-    Bundler.with_clean_env do
+    Bundler.with_original_env do
       Kernel.system target_command
     end
   end

--- a/spec/synchronised_migration/main_spec.rb
+++ b/spec/synchronised_migration/main_spec.rb
@@ -27,7 +27,7 @@ describe SynchronisedMigration::Main do
         method.call *args
       }
 
-      allow(Bundler).to receive(:with_clean_env).and_call_original
+      allow(Bundler).to receive(:with_original_env).and_call_original
 
       stub_const(
         'RedisConfig', double(
@@ -47,7 +47,7 @@ describe SynchronisedMigration::Main do
         expect(redis).to have_received(:get).with('migration-failed')
         expect(redis).to have_received(:set).with('migration-failed', 1)
         expect(Kernel).to have_received(:system)
-        expect(Bundler).not_to have_received(:with_clean_env)
+        expect(Bundler).not_to have_received(:with_original_env)
         expect(redis).to have_received(:del).with('migration-failed')
       end
     end
@@ -61,7 +61,7 @@ describe SynchronisedMigration::Main do
       it 'executes it with a clean Bundler environment' do
         expect(result).to be_success
         expect(Kernel).to have_received(:system)
-        expect(Bundler).to have_received(:with_clean_env)
+        expect(Bundler).to have_received(:with_original_env)
       end
     end
 


### PR DESCRIPTION
# Why?

`with_clean_env` will also remove the original environment variables used by the original Bundler environment.  `with_original_env` on the other hand will restore the variables as is which makes the original Bundler environment work.

# Testing

I have tested this in our testing environment.