### PR TITLE
TT-5896: Early exit from migration inside lock if already completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Synchronised Migration
 
+## Unreleased
+
+* [TT-5896] Early exit from migration inside lock if already completed
+
 ## 2.1.0
 
 * [TT-5827] Add "success key" when REDLOCK_VERSION_SUFFIX is set, preventing repeat runs

--- a/spec/synchronised_migration/main_spec.rb
+++ b/spec/synchronised_migration/main_spec.rb
@@ -28,8 +28,14 @@ describe SynchronisedMigration::Main do
         case key
         when "migration-failed-#{version_suffix}"
           fail_marker_value
+        when "migration-failed"
+          fail_marker_value
         when "migration-success-#{version_suffix}"
           success_marker_value
+        when "migration-success"
+          success_marker_value
+        else
+          raise "invalid key for redis get: #{key}"
         end
       }
       allow(redis).to receive(:set)


### PR DESCRIPTION
Synchronised migration can skip if success key is present after entering the lock (see also: TOCTOU).

This helps case where several servers spawn at once during deployments; only the first one will execute the migration, each one following will get the lock and early exit after re-validating the success key.